### PR TITLE
Add support for colors of shape (4,) for compatibility with matplotlib cmaps.

### DIFF
--- a/fresnel/color.py
+++ b/fresnel/color.py
@@ -22,7 +22,7 @@ def linear(color):
 
     Args:
 
-        color (`numpy.ndarray` or `array_like`): (``3``, ``Nx3``, or ``Nx4`` : ``float32``) - ``RGB`` or ``RGBA``
+        color (`numpy.ndarray` or `array_like`): (``3``, ``4``, ``Nx3``, or ``Nx4`` : ``float32``) - ``RGB`` or ``RGBA``
             color in the range [0,1].
 
     Returns:
@@ -31,7 +31,7 @@ def linear(color):
     """
 
     c = numpy.ascontiguousarray(color);
-    if c.shape == (3,):
+    if c.shape == (3,) or c.shape == (4,):
         out = numpy.zeros(3, dtype=numpy.float32)
         if c[0] < 0.04045:
             out[0] = c[0] / 12.92;
@@ -56,6 +56,6 @@ def linear(color):
             not_s = numpy.logical_not(s);
             out[not_s, i] = ((c[not_s,i] + 0.055) / (1.055))**2.4;
     else:
-        raise TypeError("color must be a length 3, Nx3, or Nx4 array");
+        raise TypeError("color must be a length 3, 4, Nx3, or Nx4 array");
 
     return out;


### PR DESCRIPTION
## Description

This PR adds support for linearizing colors with shape `(4,)`, the default returned by matplotlib colormaps.

## Preview

```python
>>> import fresnel, matplotlib.cm
>>> matplotlib.cm.get_cmap('tab10')(0)
(0.12156862745098039, 0.4666666666666667, 0.7058823529411765, 1.0)
>>> fresnel.color.linear(matplotlib.cm.get_cmap('tab10')(0))
array([0.01370208, 0.18447499, 0.45641103], dtype=float32)
```

## Change log

```
Added support for linearizing colors of shape (4,).
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
