### PR TITLE
Use modern cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
       python-version:
         type: string
     docker:
-      - image: glotzerlab/ci:2018.10-<< parameters.image >>
+      - image: glotzerlab/ci:2019.05-<< parameters.image >>
     environment:
       PYTHONPATH: /home/ci/project/build
       PYTHON: "/usr/bin/python<< parameters.python-version >>"
@@ -65,6 +65,7 @@ commands:
   sphinx:
     steps:
       - run: cd code/doc && sphinx-build -b html -d _build/doctrees -W -n . _build/html
+      - run: cd code/sphinx-doc && sphinx-build -b latex -d _build/doctrees -W -n . _build/latex
 
 jobs:
   build_and_test:
@@ -110,6 +111,27 @@ workflows:
       - sphinx-docs
 
       - build_and_test:
+          name: clang8-py37
+          image: ubuntu19.04
+          cc: clang-8
+          cxx: clang++-8
+          python-version: "3.7"
+
+      - build_and_test:
+          name: clang7-py37
+          image: ubuntu19.04
+          cc: clang-7
+          cxx: clang++-7
+          python-version: "3.7"
+
+      - build_and_test:
+          name: gcc9-py37
+          image: ubuntu19.04
+          cc: gcc-9
+          cxx: g++-9
+          python-version: "3.7"
+
+      - build_and_test:
           name: gcc8-py36
           image: ubuntu18.04
           cc: gcc-8
@@ -132,6 +154,20 @@ workflows:
           python-version: "3.6"
 
       - build_and_test:
+          name: gcc5-py36
+          image: ubuntu18.04
+          cc: gcc-5
+          cxx: g++-5
+          python-version: "3.6"
+
+      - build_and_test:
+          name: gcc48-py36
+          image: ubuntu18.04
+          cc: gcc-4.8
+          cxx: g++-4.8
+          python-version: "3.6"
+
+      - build_and_test:
           name: clang6-py36
           image: ubuntu18.04
           cc: clang-6.0
@@ -144,32 +180,3 @@ workflows:
           cc: clang-5.0
           cxx: clang++-5.0
           python-version: "3.6"
-
-      - build_and_test:
-          name: clang4-py36
-          image: ubuntu18.04
-          cc: clang-4.0
-          cxx: clang++-4.0
-          python-version: "3.6"
-
-      - build_and_test:
-          name: gcc5-py27
-          image: ubuntu16.04
-          cc: gcc-5
-          cxx: g++-5
-          python-version: "2.7"
-
-      - build_and_test:
-          name: clang38-py35
-          image: ubuntu16.04
-          cc: clang-3.8
-          cxx: clang++-3.8
-          python-version: "3.5"
-
-      - build_and_test:
-          name: gcc48-py35-cm28
-          image: ubuntu16.04
-          cc: gcc-4.8
-          cxx: g++-4.8
-          python-version: "3.5"
-          cmake: /opt/cmake-2.8.12/bin/cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
   sphinx:
     steps:
       - run: cd code/doc && sphinx-build -b html -d _build/doctrees -W -n . _build/html
-      - run: cd code/sphinx-doc && sphinx-build -b latex -d _build/doctrees -W -n . _build/latex
+      - run: cd code/doc && sphinx-build -b latex -d _build/doctrees -W -n . _build/latex
 
 jobs:
   build_and_test:

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,18 +8,18 @@ pipeline
         stage('Unit and validation tests')
             {
             when { not { branch 'release' } }
-            failFast true
+
             parallel
                 {
                 stage('cuda9-optix51')
                     {
-                    agent { label 'gpu' }
+                    agent { label 'gpu-short' }
 
                     environment
                         {
                         CC = 'gcc'
                         CXX = 'g++'
-                        CONTAINER = '/nfs/glotzer/containers/ci-optix-2018.10.simg'
+                        CONTAINER = '/nfs/turbo/glotzer/containers/ci/ci-2019.05-cuda9-optix51.simg'
                         }
 
                     steps
@@ -50,7 +50,62 @@ pipeline
                                 {
                                 sh '''
                                     export PYTHONPATH=${WORKSPACE}/build
-                                    singularity exec --nv ${CONTAINER} py.test-3 --junit-xml=${WORKSPACE}/test.xml
+                                    singularity exec --nv ${CONTAINER} /usr/bin/python3.6 -m pytest --junit-xml=${WORKSPACE}/test.xml
+                                   '''
+                                }
+                            }
+
+                        junit 'test.xml'
+                        }
+                    post
+                        {
+                        always
+                            {
+                            archive 'test.xml'
+                            deleteDir()
+                            }
+                        }
+                    }
+                stage('cuda10-optix51')
+                    {
+                    agent { label 'gpu-short' }
+
+                    environment
+                        {
+                        CC = 'gcc'
+                        CXX = 'g++'
+                        CONTAINER = '/nfs/turbo/glotzer/containers/ci/ci-2019.05-cuda10-optix51.simg'
+                        }
+
+                    steps
+                        {
+                        sh 'echo ${NODE_NAME}'
+
+                        dir('code')
+                            {
+                            checkout scm
+                            sh 'git submodule update --init'
+                            }
+
+                        dir('build')
+                            {
+                            timeout(time: 1, unit: 'HOURS')
+                                {
+                                sh '''
+                                    singularity exec --nv ${CONTAINER} cmake ../code -DPYTHON_EXECUTABLE=/usr/bin/python3.6 -DENABLE_EMBREE=OFF -DENABLE_OPTIX=ON -GNinja
+                                   '''
+
+                                sh 'singularity exec --nv ${CONTAINER} ninja -j 3'
+                                }
+                            }
+
+                        dir('code/test')
+                            {
+                            timeout(time: 2, unit: 'HOURS')
+                                {
+                                sh '''
+                                    export PYTHONPATH=${WORKSPACE}/build
+                                    singularity exec --nv ${CONTAINER} /usr/bin/python3.6 -m pytest --junit-xml=${WORKSPACE}/test.xml
                                    '''
                                 }
                             }

--- a/.jenkins/Jenkinsfile.jinja
+++ b/.jenkins/Jenkinsfile.jinja
@@ -8,7 +8,7 @@ pipeline
         stage('Unit and validation tests')
             {
             when { not { branch 'release' } }
-            failFast true
+
             parallel
                 {
                 {% for test in tests %}stage('{{ test.name }}')
@@ -19,7 +19,7 @@ pipeline
                         {
                         CC = '{{ test.CC }}'
                         CXX = '{{ test.CXX }}'
-                        CONTAINER = '/nfs/glotzer/containers/{{ test.CONTAINER }}'
+                        CONTAINER = '/nfs/turbo/glotzer/containers/ci/{{ test.CONTAINER }}'
                         }
 
                     steps
@@ -37,7 +37,7 @@ pipeline
                             timeout(time: 1, unit: 'HOURS')
                                 {
                                 sh '''
-                                    singularity exec --nv ${CONTAINER} {{ test.CMAKE }} ../code -DPYTHON_EXECUTABLE=/usr/bin/python{{ test.PYVER }} -DENABLE_EMBREE={{ test.ENABLE_EMBREE }} -DENABLE_OPTIX={{ test.ENABLE_OPTIX }} -GNinja
+                                    singularity exec --nv ${CONTAINER} cmake ../code -DPYTHON_EXECUTABLE=/usr/bin/python{{ test.PYVER }} -DENABLE_EMBREE={{ test.ENABLE_EMBREE }} -DENABLE_OPTIX={{ test.ENABLE_OPTIX }} -GNinja
                                    '''
 
                                 sh 'singularity exec --nv ${CONTAINER} ninja -j 3'
@@ -50,7 +50,7 @@ pipeline
                                 {
                                 sh '''
                                     export PYTHONPATH=${WORKSPACE}/build
-                                    singularity exec --nv ${CONTAINER} {{ test.PYTEST }} --junit-xml=${WORKSPACE}/test.xml
+                                    singularity exec --nv ${CONTAINER} /usr/bin/python{{ test.PYVER }} -m pytest --junit-xml=${WORKSPACE}/test.xml
                                    '''
                                 }
                             }

--- a/.jenkins/make_jenkinsfile.py
+++ b/.jenkins/make_jenkinsfile.py
@@ -6,15 +6,23 @@ template = env.get_template('Jenkinsfile.jinja')
 tests = []
 
 tests.append(dict(name='cuda9-optix51',
-                  agent='gpu',
+                  agent='gpu-short',
                   CC = 'gcc',
                   CXX = 'g++',
                   PYVER = '3.6',
-                  PYTEST = 'py.test-3',
-                  CMAKE = 'cmake',
                   ENABLE_OPTIX = 'ON',
                   ENABLE_EMBREE = 'OFF',
-                  CONTAINER = 'ci-optix-2018.10.simg',
+                  CONTAINER = 'ci-2019.05-cuda9-optix51.simg',
+                  timeout=2))
+
+tests.append(dict(name='cuda10-optix51',
+                  agent='gpu-short',
+                  CC = 'gcc',
+                  CXX = 'g++',
+                  PYVER = '3.6',
+                  ENABLE_OPTIX = 'ON',
+                  ENABLE_EMBREE = 'OFF',
+                  CONTAINER = 'ci-2019.05-cuda10-optix51.simg',
                   timeout=2))
 
 print(template.render(tests=tests))

--- a/CMake/CFlagsSetup.cmake
+++ b/CMake/CFlagsSetup.cmake
@@ -6,28 +6,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# enable C++11
-if (CMAKE_VERSION VERSION_GREATER 3.0.99)
-    # let cmake set the flags
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    # findcuda needs to be told explicitly to use c++11 as CMAKE_CXX_STANDARD does not modify CMAKE_CXX_FLAGS
-    list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
-else()
-    # manually enable flags
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
-
-if (CMAKE_VERSION VERSION_LESS 3.3.0)
-    # older versions of cmake don't handle C++11 in FindCUDA - attempt to work around this.
-    set(CUDA_NVCC_FLAGS_DEBUG "${CUDA_NVCC_FLAGS_DEBUG} -std=c++11")
-    set(CUDA_NVCC_FLAGS_MINSIZEREL "${CUDA_NVCC_FLAGS_MINSIZERE} -std=c++11")
-    set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE} -std=c++11")
-    set(CUDA_NVCC_FLAGS_RELWITHDEBINFO "${CUDA_NVCC_FLAGS_RELWITHDEBINFO} -std=c++11")
-endif()
-
-# Enable compiler warnings on gcc and clang (common compilers used by developers)
-if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unknown-pragmas -Wno-deprecated-declarations")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas")
-endif()
+# let cmake set the flags
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# findcuda needs to be told explicitly to use c++11 as CMAKE_CXX_STANDARD does not modify CMAKE_CXX_FLAGS
+list(APPEND CUDA_NVCC_FLAGS "-std=c++11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
-project(fresnel)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+project(fresnel LANGUAGES C CXX)
 
 add_subdirectory(CMake)
 include(CFlagsSetup)
@@ -26,11 +26,15 @@ endif()
 option(ENABLE_OPTIX "Use OptiX for ray tracing on the GPU" OFF)
 
 if (ENABLE_OPTIX)
+    enable_language(CUDA)
+    if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 9.0)
+        message(SEND_ERROR "Fresnel requires CUDA 9.0 or newer")
+    endif()
+
     find_package(OptiX REQUIRED)
-    find_package(CUDA 7.5 REQUIRED)
 
     include_directories(${OptiX_INCLUDE})
-    include_directories(${CUDA_INCLUDE_DIRS})
+    include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 endif()
 
 if (NOT (ENABLE_OPTIX) AND NOT (ENABLE_EMBREE))

--- a/fresnel/CMakeLists.txt
+++ b/fresnel/CMakeLists.txt
@@ -46,23 +46,45 @@ if (ENABLE_OPTIX)
 target_compile_definitions(_common PUBLIC FRESNEL_BUILD_GPU)
 
 # Build the PTX files for the OptiX programs
-set(_ptx_sources
-	gpu/direct.cu
-    gpu/path.cu
-    gpu/GeometryCylinder.cu
-    gpu/GeometryMesh.cu
-    gpu/GeometrySphere.cu
-    gpu/GeometryPolygon.cu
-    gpu/GeometryConvexPolyhedron.cu)
+set(_ptx_files
+    direct
+    path
+    GeometryCylinder
+    GeometryMesh
+    GeometrySphere
+    GeometryPolygon
+    GeometryConvexPolyhedron
+    )
 
-list(APPEND CUDA_NVCC_FLAGS "-Xcudafe;--diag_suppress=code_is_unreachable")
-list(APPEND CUDA_NVCC_FLAGS "-arch;compute_30;--use_fast_math")
-CUDA_WRAP_SRCS(_ptx PTX generated_ptx_files ${_ptx_sources})
-add_custom_target(_ptx ALL
-    DEPENDS ${generated_ptx_files} ${_ptx_sources}
-    SOURCES ${_ptx_sources})
+set(_ptx_sources "")
+set(_ptx_outputs "")
 
-install(FILES ${generated_ptx_files}
+foreach(ptx_file ${_ptx_files})
+    list(APPEND _ptx_sources "gpu/${ptx_file}.cu")
+    list(APPEND _ptx_outputs "${ptx_file}.ptx")
+endforeach()
+
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=code_is_unreachable")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch compute_30 --use_fast_math")
+
+add_library(_ptx OBJECT ${_ptx_sources})
+set_property(TARGET _ptx PROPERTY CUDA_PTX_COMPILATION ON)
+target_compile_features(_ptx PUBLIC cxx_std_11)
+
+add_custom_command(
+  OUTPUT ${_ptx_outputs}
+  COMMAND ${CMAKE_COMMAND}
+    "-DOBJECTS=$<TARGET_OBJECTS:_ptx>"
+    "-DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/copy_wrapper.cmake
+  VERBATIM
+  DEPENDS $<TARGET_OBJECTS:_ptx>
+  COMMENT "Copying ptx files"
+)
+
+add_custom_target(copy_ptx ALL DEPENDS ${_ptx_outputs})
+
+install(FILES $<TARGET_OBJECTS:_ptx>
         DESTINATION ${PYTHON_MODULE_BASE_DIR}
        )
 

--- a/fresnel/common/Camera.h
+++ b/fresnel/common/Camera.h
@@ -9,7 +9,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/ColorMath.h
+++ b/fresnel/common/ColorMath.h
@@ -7,7 +7,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE
@@ -39,7 +39,7 @@ struct RGB
         {
         }
 
-    #ifdef NVCC
+    #ifdef __CUDA_ARCH__
     //! Convenience function to generate float3 in device code
     DEVICE operator float3()
         {

--- a/fresnel/common/GeometryMath.h
+++ b/fresnel/common/GeometryMath.h
@@ -7,7 +7,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/IntersectCylinder.h
+++ b/fresnel/common/IntersectCylinder.h
@@ -10,7 +10,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/IntersectSphere.h
+++ b/fresnel/common/IntersectSphere.h
@@ -7,7 +7,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/IntersectTriangle.h
+++ b/fresnel/common/IntersectTriangle.h
@@ -10,7 +10,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/Light.h
+++ b/fresnel/common/Light.h
@@ -11,7 +11,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/Material.h
+++ b/fresnel/common/Material.h
@@ -10,7 +10,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/RayGen.h
+++ b/fresnel/common/RayGen.h
@@ -15,7 +15,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/TracerPathMethods.h
+++ b/fresnel/common/TracerPathMethods.h
@@ -8,7 +8,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE

--- a/fresnel/common/VectorMath.h
+++ b/fresnel/common/VectorMath.h
@@ -10,7 +10,7 @@
 // need to declare these class methods with __device__ qualifiers when building in nvcc
 // DEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
 #undef DEVICE
-#ifdef NVCC
+#ifdef __CUDACC__
 #define DEVICE __host__ __device__
 #else
 #define DEVICE
@@ -332,7 +332,7 @@ struct vec3
     //! Construct an undefined vec3
     DEVICE vec3() { }
 
-    #ifdef NVCC
+    #ifdef __CUDACC__
     //! Convenience function to generate float3 in device code
     DEVICE operator float3()
         {
@@ -643,7 +643,7 @@ struct vec2
         {
         }
 
-    #ifdef NVCC
+    #ifdef __CUDACC__
     //! Convenience function to generate float2 in device code
     DEVICE operator float2()
         {
@@ -976,7 +976,7 @@ struct quat
         {
         }
 
-    #ifdef NVCC
+    #ifdef __CUDACC__
     //! Convenience function to get a quat from a float4 in device code
     DEVICE explicit quat(const float4& a) : s(a.x), v(vec3<float>(a.y, a.z, a.w))
         {

--- a/fresnel/copy_wrapper.cmake
+++ b/fresnel/copy_wrapper.cmake
@@ -1,0 +1,8 @@
+
+
+foreach(obj ${OBJECTS})
+    execute_process(COMMAND "${CMAKE_COMMAND}"
+                    -E copy_if_different ${obj} ${OUTPUT_DIR}
+                    )
+    set(file_contents "${file_contents} \n${output}")
+endforeach()

--- a/fresnel/gpu/Device.cc
+++ b/fresnel/gpu/Device.cc
@@ -42,7 +42,7 @@ Device::Device(const std::string& ptx_root, int n) : m_ptx_root(ptx_root)
     m_context->setRayTypeCount(2);
 
     // miss programs
-    optix::Program p2 = getProgram("_ptx_generated_path.cu.ptx", "path_miss");
+    optix::Program p2 = getProgram("path.ptx", "path_miss");
     m_context->setMissProgram(TRACER_PATH_RAY_ID, p2);
 
     // initialize materials

--- a/fresnel/gpu/GeometryConvexPolyhedron.cc
+++ b/fresnel/gpu/GeometryConvexPolyhedron.cc
@@ -33,7 +33,7 @@ GeometryConvexPolyhedron::GeometryConvexPolyhedron(std::shared_ptr<Scene> scene,
     m_geometry->setPrimitiveCount(N);
 
     // load bounding and intresection programs
-    const char * path_to_ptx = "_ptx_generated_GeometryConvexPolyhedron.cu.ptx";
+    const char * path_to_ptx = "GeometryConvexPolyhedron.ptx";
     bounding_box_program = device->getProgram(path_to_ptx, "bounds");
     m_geometry->setBoundingBoxProgram(bounding_box_program);
 

--- a/fresnel/gpu/GeometryCylinder.cc
+++ b/fresnel/gpu/GeometryCylinder.cc
@@ -25,7 +25,7 @@ GeometryCylinder::GeometryCylinder(std::shared_ptr<Scene> scene, unsigned int N)
 	m_geometry = context->createGeometry();
 	m_geometry->setPrimitiveCount(N);
 
-	const char * path_to_ptx = "_ptx_generated_GeometryCylinder.cu.ptx";
+	const char * path_to_ptx = "GeometryCylinder.ptx";
 	bounding_box_program = device->getProgram(path_to_ptx, "bounds");
 	m_geometry->setBoundingBoxProgram(bounding_box_program);
 

--- a/fresnel/gpu/GeometryMesh.cc
+++ b/fresnel/gpu/GeometryMesh.cc
@@ -29,7 +29,7 @@ GeometryMesh::GeometryMesh(std::shared_ptr<Scene> scene,
     m_geometry = context->createGeometry();
 
     // load bounding and intresection programs
-    const char * path_to_ptx = "_ptx_generated_GeometryMesh.cu.ptx";
+    const char * path_to_ptx = "GeometryMesh.ptx";
     bounding_box_program = device->getProgram(path_to_ptx, "bounds");
     m_geometry->setBoundingBoxProgram(bounding_box_program);
 

--- a/fresnel/gpu/GeometryPolygon.cc
+++ b/fresnel/gpu/GeometryPolygon.cc
@@ -32,7 +32,7 @@ GeometryPolygon::GeometryPolygon(std::shared_ptr<Scene> scene,
     m_geometry->setPrimitiveCount(N);
 
     // load bounding and intresection programs
-    const char * path_to_ptx = "_ptx_generated_GeometryPolygon.cu.ptx";
+    const char * path_to_ptx = "GeometryPolygon.ptx";
     bounding_box_program = device->getProgram(path_to_ptx, "bounds");
     m_geometry->setBoundingBoxProgram(bounding_box_program);
 

--- a/fresnel/gpu/GeometrySphere.cc
+++ b/fresnel/gpu/GeometrySphere.cc
@@ -25,7 +25,7 @@ namespace fresnel { namespace gpu {
 		m_geometry = context->createGeometry();
 		m_geometry->setPrimitiveCount(N);
 
-		const char * path_to_ptx = "_ptx_generated_GeometrySphere.cu.ptx";
+		const char * path_to_ptx = "GeometrySphere.ptx";
 		bounding_box_program = device->getProgram(path_to_ptx, "bounds");
 		m_geometry->setBoundingBoxProgram(bounding_box_program);
 

--- a/fresnel/gpu/TracerDirect.cc
+++ b/fresnel/gpu/TracerDirect.cc
@@ -17,11 +17,11 @@ TracerDirect::TracerDirect(std::shared_ptr<Device> device, unsigned int w, unsig
     {
     // create the entry point program
     optix::Context context = m_device->getContext();
-    m_ray_gen = m_device->getProgram("_ptx_generated_direct.cu.ptx", "direct_ray_gen");
-    m_ray_gen_entry = m_device->getEntryPoint("_ptx_generated_direct.cu.ptx", "direct_ray_gen");
+    m_ray_gen = m_device->getProgram("direct.ptx", "direct_ray_gen");
+    m_ray_gen_entry = m_device->getEntryPoint("direct.ptx", "direct_ray_gen");
 
     // load the exception program
-    m_exception_program = m_device->getProgram("_ptx_generated_direct.cu.ptx", "direct_exception");
+    m_exception_program = m_device->getProgram("direct.ptx", "direct_exception");
     context->setExceptionProgram(m_ray_gen_entry, m_exception_program);
     }
 
@@ -32,7 +32,7 @@ TracerDirect::~TracerDirect()
 //! Initialize the Material for use in tracing
 void TracerDirect::setupMaterial(optix::Material mat, Device *dev)
     {
-    optix::Program p = dev->getProgram("_ptx_generated_direct.cu.ptx", "direct_closest_hit");
+    optix::Program p = dev->getProgram("direct.ptx", "direct_closest_hit");
     mat->setClosestHitProgram(TRACER_PREVIEW_RAY_ID, p);
     }
 

--- a/fresnel/gpu/TracerPath.cc
+++ b/fresnel/gpu/TracerPath.cc
@@ -18,11 +18,11 @@ TracerPath::TracerPath(std::shared_ptr<Device> device, unsigned int w, unsigned 
     {
     // create the entry point program
     optix::Context context = m_device->getContext();
-    m_ray_gen = m_device->getProgram("_ptx_generated_path.cu.ptx", "path_ray_gen");
-    m_ray_gen_entry = m_device->getEntryPoint("_ptx_generated_path.cu.ptx", "path_ray_gen");
+    m_ray_gen = m_device->getProgram("path.ptx", "path_ray_gen");
+    m_ray_gen_entry = m_device->getEntryPoint("path.ptx", "path_ray_gen");
 
     // load the exception program
-    m_exception_program = m_device->getProgram("_ptx_generated_path.cu.ptx", "path_exception");
+    m_exception_program = m_device->getProgram("path.ptx", "path_exception");
     context->setExceptionProgram(m_ray_gen_entry, m_exception_program);
     reset();
     }
@@ -48,7 +48,7 @@ void TracerPath::reset()
 //! Initialize the Material for use in tracing
 void TracerPath::setupMaterial(optix::Material mat, Device *dev)
     {
-    optix::Program p = dev->getProgram("_ptx_generated_path.cu.ptx", "path_closest_hit");
+    optix::Program p = dev->getProgram("path.ptx", "path_closest_hit");
     mat->setClosestHitProgram(TRACER_PATH_RAY_ID, p);
     }
 

--- a/fresnel/gpu/direct.cu
+++ b/fresnel/gpu/direct.cu
@@ -209,6 +209,6 @@ RT_PROGRAM void direct_closest_hit()
             }
         }
 
-    prd_radiance.result = c;
+    prd_radiance.result = float3(c);
     prd_radiance.hit = 1;
     }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Use CUDA first class language support in CMake.

## Motivation and context

`FindCUDA.cmake` is deprecated. We need to use actively developed features going forward. This also greatly simplifies the CMake code.

## Change log

<!-- Propose a change log entry. -->
```
- CMake v3.8 or newer is now required to build fresnel
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
