### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @glotzerlab/fresnel-maintainers-pullassigner @glotzerlab/fresnel-contributors-pullassigner

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,4 @@ Resolves: #???
 - [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
 - [ ] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
 - [ ] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
+- [ ] I am a member of the [fresnel-contributors team](https://github.com/orgs/glotzerlab/teams/fresnel-contributors/members).


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
`CODEOWNERS` sets default reviewers for pull requests. 

The changes in this PR will request one fresnel maintainer and one fresnel contributor review the PR using  Pull Assigner (https://docs.pullpanda.com/products/assigner) to distribute the work among team members. Maintainer review is needed for final approval and merging. Review from a contributor provides an important cross check.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Assigning PRs to reviewers will help complete the feedback loop and get them merged more quickly. The Pull Assigner bot will distribute the load so that no one individual is responsible for all reviews.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
This PR itself is the test.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
