### PR TITLE
Add git submodules to readthedocs.yml configuration.

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,5 +2,10 @@ version: 2
 
 python:
   version: 3.7
+
 conda:
     environment: doc/environment.yml
+
+submodules:
+    include: all
+    recursive: true


### PR DESCRIPTION
## Description

Fixed inclusion of git submodules in ReadTheDocs builds.

Resolves: #87.

## Preview

Current docs builds lack tutorials: https://fresnel.readthedocs.io/en/v0.10.0/

This fixed that issue, see this tutorial: https://fresnel.readthedocs.io/en/docs-include-submodules/examples/00-Basic-tutorials/05-Lighting-setups.html#Rembrandt

## Change log

```
Fixed ReadTheDocs builds to include git submodules.
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
- [x] I am a member of the [fresnel-contributors team](https://github.com/orgs/glotzerlab/teams/fresnel-contributors/members).
