### PR TITLE
Update INSTALLING.rst

### DIFF
--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -80,7 +80,7 @@ Install Prerequisites
 * C++11 capable compiler
 * CMake >= 3.8
 * pybind11 >= 2.2
-* Python >= 3.5
+* Python >= 3.6
 * numpy
 * Qhull >= 2015.2
 * For CPU execution (required when ``ENABLE_EMBREE=ON``):


### PR DESCRIPTION
Documenting that python 3.5 is no longer supported

## Description
We have some `f-strings` in tests now which will fail in a python 3.5 environment. 



## Change log

<!-- Propose a change log entry. -->
```

- Drop Python 3.5 support

```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
