### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if (ENABLE_EMBREE)
         add_library(EMBREE::embree UNKNOWN IMPORTED)
         set_target_properties(EMBREE::embree PROPERTIES
             IMPORTED_LOCATION "${EMBREE_LIBRARY}"
-            INTERFACE_INCLUDE_DIRECTORIES "${EMBREE_INCLUDE_DIR}"
+            INTERFACE_INCLUDE_DIRECTORIES "${EMBREE_INCLUDE_DIRS}"
             IMPORTED_LINK_INTERFACE_LIBRARIES "TBB::tbb")
     endif()
 


### PR DESCRIPTION
Use the correct variable to find the embree headers.

## Description

There was a typo in the CMakeLists file for finding embree header files.


## Change log


```
- Fix typo in CMakeLists.txt where embree header location is found
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
