### PR TITLE
Use 2019.11 CI image with Python 3.8 final.

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -1,6 +1,6 @@
 variables:
-  image_root: glotzerlab/ci:2019.10
-  private_image_root: joaander/ci:2019.10
+  image_root: glotzerlab/ci:2019.11
+  private_image_root: joaander/ci:2019.11
 
 stages:
 - stage: build_test_cpu


### PR DESCRIPTION
## Description

Previous CI images were built with an alpha of Python 3.8. This updates the CI config to use Python 3.8 final.

Resolves: #97.

## Change log

No changelog required.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
