### PR TITLE
Error when fitting camera with no geometry.

### DIFF
--- a/fresnel/camera.py
+++ b/fresnel/camera.py
@@ -136,7 +136,7 @@ def orthographic(position, look_at, up, height):
 def fit(scene, view='auto', margin=0.05):
     R""" Fit a camera to a :py:class:`Scene <fresnel.Scene>`
 
-    Create a camera that fits the entire hight of the scene in the image plane.
+    Create a camera that fits the entire height of the scene in the image plane.
 
     Args:
         scene (:py:class:`Scene <fresnel.Scene>`): The scene to fit the camera to.

--- a/fresnel/camera.py
+++ b/fresnel/camera.py
@@ -157,6 +157,11 @@ def fit(scene, view='auto', margin=0.05):
                                  right = numpy.array([1, 0, -1])/math.sqrt(2))
               }
 
+    # raise error if the scene is empty
+    if len(scene.geometry) == 0:
+        raise ValueError('The camera cannot be fit because the scene has no geometries. '
+                         'Add geometries to the scene before calling fit.')
+
     # find the center of the scene
     extents = scene.get_extents();
 

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -1,4 +1,12 @@
 import fresnel
+import pytest
+
+def test_camera_fit_no_geometry(device_):
+    scene = fresnel.Scene()
+
+    # fit cannot be called on a scene with no geometries
+    with pytest.raises(ValueError):
+        cam = fresnel.camera.fit(scene, view='front', margin=0)
 
 def test_camera_fit_front(device_):
     scene = fresnel.Scene()

--- a/test/test_scene.py
+++ b/test/test_scene.py
@@ -19,6 +19,7 @@ def test_background_color(device_):
 
     assert scene.background_alpha == 0.5
 
+    scene.camera = fresnel.camera.orthographic(position=(0, 0, 10), look_at=(0,0,0), up=(0,1,0), height=7)
     buf_proxy = fresnel.preview(scene, w=100, h=100)
     buf = buf_proxy[:]
 


### PR DESCRIPTION
## Description

Throws an error if the user tries to fit a camera in a scene with no geometry.

Resolves: #72

## Change log

```
An error is raised if a user attempts to fit a camera in a scene with no geometry.
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).