### PR TITLE
Switch aa_level setting to anti_alias switch, default on

### DIFF
--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -11,6 +11,7 @@ The following people contributed to **fresnel**.
 * Bryan VanSaders, University of Michigan
 * Mike Henry, Boise State University
 * Jenny Fothergill, Boise State University
+* Corwin Kerr, University of Michigan
 
 Libraries
 ---------

--- a/fresnel/__init__.py
+++ b/fresnel/__init__.py
@@ -290,7 +290,7 @@ class Scene(object):
             cam = camera.fit(self);
             self._scene.setCamera(cam._camera);
 
-def preview(scene, w=600, h=370, aa_level=0):
+def preview(scene, w=600, h=370, anti_alias=True):
     R""" Preview a scene.
 
     Args:
@@ -298,13 +298,13 @@ def preview(scene, w=600, h=370, aa_level=0):
         scene (:py:class:`Scene`): Scene to render.
         w (int): Output image width.
         h (int): Output image height.
-        aa_level (int): Amount of anti-aliasing to perform
+        anti_alias (bool): Whether to perform anti-aliasing
 
     :py:func:`preview` is a shortcut to rendering output with the :py:class:`Preview <tracer.Preview>` tracer.
     See the :py:class:`Preview <tracer.Preview>` tracer for a complete description.
     """
 
-    t = tracer.Preview(scene.device, w=w, h=h, aa_level=aa_level);
+    t = tracer.Preview(scene.device, w=w, h=h, anti_alias=anti_alias);
     return t.render(scene);
 
 def pathtrace(scene, w=600, h=370, samples=64, light_samples=1):

--- a/fresnel/__init__.py
+++ b/fresnel/__init__.py
@@ -298,7 +298,7 @@ def preview(scene, w=600, h=370, anti_alias=True):
         scene (:py:class:`Scene`): Scene to render.
         w (int): Output image width.
         h (int): Output image height.
-        anti_alias (bool): Whether to perform anti-aliasing
+        anti_alias (bool): Whether to perform anti-aliasing.
 
     :py:func:`preview` is a shortcut to rendering output with the :py:class:`Preview <tracer.Preview>` tracer.
     See the :py:class:`Preview <tracer.Preview>` tracer for a complete description.

--- a/fresnel/tracer.py
+++ b/fresnel/tracer.py
@@ -162,6 +162,7 @@ class Preview(Tracer):
     .. rubric:: Anti-aliasing
 
     The default value of :py:attr:`anti_alias` is True to smooth sharp edges in the image.
+    The anti-aliasing level corresponds to aa_level=3 in fresnel versions up to 0.11.0.
     Different :py:attr:`seed <Tracer.seed>` values will result in different output images.
 
     TODO: show examples

--- a/fresnel/tracer.py
+++ b/fresnel/tracer.py
@@ -165,10 +165,6 @@ class Preview(Tracer):
     Different :py:attr:`seed <Tracer.seed>` values will result in different output images.
 
     TODO: show examples
-
-    .. tip::
-
-        Use :py:attr:`aa_level` = 3 when using the :py:class:`Preview` tracer to render production quality output.
     """
 
     def __init__(self, device, w, h, anti_alias=True):

--- a/fresnel/tracer.py
+++ b/fresnel/tracer.py
@@ -149,11 +149,7 @@ class Preview(Tracer):
         device (:py:class:`Device <fresnel.Device>`): Device to use for rendering.
         w (int): Output image width.
         h (int): Output image height.
-        aa_level (int): Amount of anti-aliasing to perform
-
-    Attributes:
-
-        aa_level (int): Amount of anti-aliasing to perform
+        anti_alias (bool): Whether to perform anti-aliasing. If True, uses 8x8 subpixel grid.
 
     .. rubric:: Overview
 
@@ -165,9 +161,7 @@ class Preview(Tracer):
 
     .. rubric:: Anti-aliasing
 
-    Set :py:attr:`aa_level` to control the amount of anti-aliasing performed. The default value of 0 performs
-    no anti-aliasing to enable the fastest possible preview renders. A value of 1 samples 2x2 subpixels, a value of 2
-    samples 4x4 subpixels, a value of 3 samples 8x8 subpixels, etc ... Samples are jittered with random numbers.
+    The default value of :py:attr:`anti_alias` is True to smooth sharp edges in the image.
     Different :py:attr:`seed <Tracer.seed>` values will result in different output images.
 
     TODO: show examples
@@ -177,21 +171,23 @@ class Preview(Tracer):
         Use :py:attr:`aa_level` = 3 when using the :py:class:`Preview` tracer to render production quality output.
     """
 
-    def __init__(self, device, w, h, aa_level=0):
+    def __init__(self, device, w, h, anti_alias=True):
         self.device = device;
         self._tracer = device.module.TracerDirect(device._device, w, h);
-
-        self.aa_level = aa_level;
+        self.anti_alias = anti_alias
 
     @property
-    def aa_level(self):
-        aa_n = self._tracer.getAntialiasingN();
-        return int(math.log2(aa_n));
+    def anti_alias(self):
+        R""" Whether to perform anti-aliasing
+        """
+        return self._tracer.getAntialiasingN() > 1
 
-    @aa_level.setter
-    def aa_level(self, value):
-        aa_n = 2**(int(value))
-        self._tracer.setAntialiasingN(aa_n);
+    @anti_alias.setter
+    def anti_alias(self, value):
+        if value:
+            self._tracer.setAntialiasingN(8)
+        else:
+            self._tracer.setAntialiasingN(1)
 
 class Path(Tracer):
     R""" Path tracer.

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -25,7 +25,7 @@ def test_scene_auto(device_):
     geom1 = fresnel.geometry.Sphere(scene, position = [[-9, -2, 0], [-5, -1, 0], [4, 0, 0], [2, 1, 0]], radius=1.0)
     assert scene.camera == 'auto';
 
-    fresnel.preview(scene)
+    fresnel.preview(scene, anti_alias=False)
 
 def test_orthographic_attributes():
     cam = fresnel.camera.orthographic(position=(1, 0, 10), look_at=(1,0,0), up=(0,1,0), height=6)

--- a/test/test_geometry_box.py
+++ b/test/test_geometry_box.py
@@ -35,7 +35,7 @@ def scene_box_(device_):
 
 
 def test_render(scene_box_, generate=False):
-    buf_proxy = fresnel.preview(scene_box_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_box_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode="RGBA").save(
@@ -54,7 +54,7 @@ def test_radius(scene_box_, generate=False):
     geometry.radius[:] = r
     numpy.testing.assert_array_equal(r, geometry.radius[:])
 
-    buf_proxy = fresnel.preview(scene_box_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_box_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode="RGBA").save(
@@ -74,7 +74,7 @@ def test_color(scene_box_, generate=False):
     geometry.color[:] = c
     numpy.testing.assert_array_equal(c, geometry.color[:])
 
-    buf_proxy = fresnel.preview(scene_box_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_box_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode="RGBA").save(
@@ -93,7 +93,7 @@ def test_box_radius(scene_box_, generate=False):
     geometry.box_radius = r
     assert r == pytest.approx(geometry.box_radius)
 
-    buf_proxy = fresnel.preview(scene_box_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_box_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode="RGBA").save(
@@ -112,7 +112,7 @@ def test_box_color(scene_box_, generate=False):
     geometry.box_color = c
     numpy.testing.assert_array_equal(c, geometry.box_color)
 
-    buf_proxy = fresnel.preview(scene_box_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_box_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode="RGBA").save(
@@ -144,7 +144,7 @@ def test_box_update(scene_box_, generate=False):
         assert isinstance(geometry.box, tuple)
         assert len(geometry.box) == 6
 
-        buf_proxy = fresnel.preview(scene_box_, w=150, h=100)
+        buf_proxy = fresnel.preview(scene_box_, w=150, h=100, anti_alias=False)
 
         box_index = box_list.index(update_box)
 

--- a/test/test_geometry_convex_polyhedron.py
+++ b/test/test_geometry_convex_polyhedron.py
@@ -65,7 +65,7 @@ def scene_eight_polyhedra_(device_):
     return scene_eight_polyhedra(device_)
 
 def test_render(scene_eight_polyhedra_, generate=False):
-    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_convex_polyhedron.test_render.png', 'wb'), 'png');
@@ -77,7 +77,7 @@ def test_outline(scene_eight_polyhedra_, generate=False):
     geometry = scene_eight_polyhedra_.geometry[0]
     geometry.outline_width = 0.1
 
-    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_convex_polyhedron.test_outline.png', 'wb'), 'png');
@@ -86,13 +86,13 @@ def test_outline(scene_eight_polyhedra_, generate=False):
 
 
 def test_face_color(scene_eight_polyhedra_, generate=False):
-    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100, anti_alias=False)
 
     geometry = scene_eight_polyhedra_.geometry[0]
     geometry.color_by_face = 1.0
     geometry.material.primitive_color_mix = 1.0
 
-    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_eight_polyhedra_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_convex_polyhedron.test_face_color.png', 'wb'), 'png');

--- a/test/test_geometry_cylinder.py
+++ b/test/test_geometry_cylinder.py
@@ -33,7 +33,7 @@ def scene_four_cylinders_(device_):
     return scene_four_cylinders(device_);
 
 def test_render(scene_four_cylinders_, generate=False):
-    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_clyinder.test_render.png', 'wb'), 'png');
@@ -47,7 +47,7 @@ def test_radius(scene_four_cylinders_, generate=False):
     geometry.radius[:] = r
     numpy.testing.assert_array_equal(r, geometry.radius[:])
 
-    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_clyinder.test_radius.png', 'wb'), 'png');
@@ -64,7 +64,7 @@ def test_points(scene_four_cylinders_, generate=False):
     geometry.points[:] = p
     numpy.testing.assert_array_equal(p, geometry.points[:])
 
-    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_clyinder.test_position.png', 'wb'), 'png');
@@ -82,7 +82,7 @@ def test_color(scene_four_cylinders_, generate=False):
     geometry.color[:] = c
     numpy.testing.assert_array_equal(c, geometry.color[:])
 
-    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_clyinder.test_color.png', 'wb'), 'png');
@@ -93,7 +93,7 @@ def test_outline(scene_four_cylinders_, generate=False):
     geometry = scene_four_cylinders_.geometry[0]
     geometry.outline_width = 0.3
 
-    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_cylinders_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_clyinder.test_outline.png', 'wb'), 'png');

--- a/test/test_geometry_mesh.py
+++ b/test/test_geometry_mesh.py
@@ -78,7 +78,7 @@ def scene_tetrahedra_(device_):
     return scene_tetrahedra(device_)
 
 def test_render(scene_one_triangle_, generate=False):
-    buf_proxy = fresnel.preview(scene_one_triangle_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_one_triangle_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_mesh.test_render.png', 'wb'), 'png');
@@ -90,7 +90,7 @@ def test_outline(scene_one_triangle_, generate=False):
     geometry = scene_one_triangle_.geometry[0]
     geometry.outline_width = 0.1
 
-    buf_proxy = fresnel.preview(scene_one_triangle_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_one_triangle_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_mesh.test_outline.png', 'wb'), 'png');
@@ -101,7 +101,7 @@ def test_color_interp(scene_one_triangle_, generate=False):
     geometry = scene_one_triangle_.geometry[0]
     geometry.material.primitive_color_mix = 1.0
 
-    buf_proxy = fresnel.preview(scene_one_triangle_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_one_triangle_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_mesh.test_color_interp.png', 'wb'), 'png');
@@ -109,7 +109,7 @@ def test_color_interp(scene_one_triangle_, generate=False):
         conftest.assert_image_approx_equal(buf_proxy[:], dir_path / 'reference' / 'test_geometry_mesh.test_color_interp.png')
 
 def test_multiple(scene_tetrahedra_, generate=False):
-    buf_proxy = fresnel.preview(scene_tetrahedra_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_tetrahedra_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_mesh.test_multiple.png', 'wb'), 'png');

--- a/test/test_geometry_polygon.py
+++ b/test/test_geometry_polygon.py
@@ -55,7 +55,7 @@ def scene_polygons_(device_):
     return scene_polygons(device_);
 
 def test_render(scene_polygons_, generate=False):
-    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_polygon.test_render.png', 'wb'), 'png');
@@ -66,7 +66,7 @@ def test_rounded(scene_rounded_polygons_, generate=False):
     geometry = scene_rounded_polygons_.geometry[0]
     geometry.outline_width = 0.1
 
-    buf_proxy = fresnel.preview(scene_rounded_polygons_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_rounded_polygons_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_polygon.test_rounded.png', 'wb'), 'png');
@@ -80,7 +80,7 @@ def test_angle(scene_polygons_, generate=False):
     geometry.angle[:] = a
     numpy.testing.assert_array_equal(a, geometry.angle[:])
 
-    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_polygon.test_angle.png', 'wb'), 'png');
@@ -95,7 +95,7 @@ def test_position(scene_polygons_, generate=False):
     geometry.position[:] = p
     numpy.testing.assert_array_equal(p, geometry.position[:])
 
-    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_polygon.test_position.png', 'wb'), 'png');
@@ -110,7 +110,7 @@ def test_color(scene_polygons_, generate=False):
     geometry.color[:] = c
     numpy.testing.assert_array_equal(c, geometry.color[:])
 
-    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_polygon.test_color.png', 'wb'), 'png');
@@ -121,7 +121,7 @@ def test_outline(scene_polygons_, generate=False):
     geometry = scene_polygons_.geometry[0]
     geometry.outline_width = 0.1
 
-    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_polygons_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_polygon.test_outline.png', 'wb'), 'png');

--- a/test/test_geometry_sphere.py
+++ b/test/test_geometry_sphere.py
@@ -36,7 +36,7 @@ def scene_four_spheres_(device_):
     return scene_four_spheres(device_);
 
 def test_render(scene_four_spheres_, generate=False):
-    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_sphere.test_render.png', 'wb'), 'png');
@@ -50,7 +50,7 @@ def test_radius(scene_four_spheres_, generate=False):
     geometry.radius[:] = r
     numpy.testing.assert_array_equal(r, geometry.radius[:])
 
-    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_sphere.test_radius.png', 'wb'), 'png');
@@ -67,7 +67,7 @@ def test_position(scene_four_spheres_, generate=False):
     geometry.position[:] = p
     numpy.testing.assert_array_equal(p, geometry.position[:])
 
-    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_sphere.test_position.png', 'wb'), 'png');
@@ -82,7 +82,7 @@ def test_color(scene_four_spheres_, generate=False):
     geometry.color[:] = c
     numpy.testing.assert_array_equal(c, geometry.color[:])
 
-    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_sphere.test_color.png', 'wb'), 'png');
@@ -93,7 +93,7 @@ def test_outline(scene_four_spheres_, generate=False):
     geometry = scene_four_spheres_.geometry[0]
     geometry.outline_width = 0.1
 
-    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100)
+    buf_proxy = fresnel.preview(scene_four_spheres_, w=150, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_geometry_sphere.test_outline.png', 'wb'), 'png');

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -14,7 +14,7 @@ def test_set_material(scene_hex_sphere_, generate=False):
     assert geometry.material.color == tuple(fresnel.color.linear([1,0,0]))
     assert geometry.material.primitive_color_mix == 0.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_set_material.png', 'wb'), 'png');
@@ -26,7 +26,7 @@ def test_solid(scene_hex_sphere_, generate=False):
     geometry.material.solid = 1.0
     assert geometry.material.solid == 1.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_solid.png', 'wb'), 'png');
@@ -38,7 +38,7 @@ def test_color(scene_hex_sphere_, generate=False):
     geometry.material.color = fresnel.color.linear([0,0,1])
     assert geometry.material.color == tuple(fresnel.color.linear([0,0,1]))
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_color.png', 'wb'), 'png');
@@ -50,7 +50,7 @@ def test_specular(scene_hex_sphere_, generate=False):
     geometry.material.specular = 1.0
     assert geometry.material.specular == 1.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_specular.png', 'wb'), 'png');
@@ -62,7 +62,7 @@ def test_roughness(scene_hex_sphere_, generate=False):
     geometry.material.roughness = 1.0
     assert geometry.material.roughness == 1.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_roughness.png', 'wb'), 'png');
@@ -74,7 +74,7 @@ def test_metal(scene_hex_sphere_, generate=False):
     geometry.material.metal = 1.0
     assert geometry.material.metal == 1.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_metal.png', 'wb'), 'png');
@@ -92,7 +92,7 @@ def test_primitive_color_mix(scene_hex_sphere_, generate=False):
     geometry.color[4] = fresnel.color.linear([0,1,1])
     geometry.color[5] = fresnel.color.linear([0,0,0])
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_material.test_primitive_color_mix.png', 'wb'), 'png');

--- a/test/test_outline_material.py
+++ b/test/test_outline_material.py
@@ -16,7 +16,7 @@ def test_set_material(scene_hex_sphere_, generate=False):
     assert geometry.outline_material.color == tuple(fresnel.color.linear([1,0,0]))
     assert geometry.outline_material.primitive_color_mix == 0.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_outline_material.test_set_material.png', 'wb'), 'png');
@@ -29,7 +29,7 @@ def test_solid(scene_hex_sphere_, generate=False):
     geometry.outline_material.solid = 1.0
     assert geometry.outline_material.solid == 1.0
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_outline_material.test_solid.png', 'wb'), 'png');
@@ -42,7 +42,7 @@ def test_color(scene_hex_sphere_, generate=False):
     geometry.outline_material.color = fresnel.color.linear([0,0,1])
     assert geometry.outline_material.color == tuple(fresnel.color.linear([0,0,1]))
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_outline_material.test_color.png', 'wb'), 'png');
@@ -61,7 +61,7 @@ def test_primitive_color_mix(scene_hex_sphere_, generate=False):
     geometry.color[4] = fresnel.color.linear([0,1,1])
     geometry.color[5] = fresnel.color.linear([0,0,0])
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_outline_material.test_primitive_color_mix.png', 'wb'), 'png');

--- a/test/test_scene.py
+++ b/test/test_scene.py
@@ -19,7 +19,7 @@ def test_background_color(device_):
 
     assert scene.background_alpha == 0.5
 
-    buf_proxy = fresnel.preview(scene, w=100, h=100)
+    buf_proxy = fresnel.preview(scene, w=100, h=100, anti_alias=False)
     buf = buf_proxy[:]
 
     numpy.testing.assert_array_equal(buf[:,:,3], numpy.ones(shape=(100,100), dtype=buf.dtype)*128)
@@ -33,7 +33,7 @@ def test_camera(scene_hex_sphere_, generate=False):
     assert scene_hex_sphere_.camera.up == (0,1,0)
     assert scene_hex_sphere_.camera.height == 6
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_scene.test_camera.png', 'wb'), 'png');
@@ -46,7 +46,7 @@ def test_light_dir(scene_hex_sphere_, generate=False):
     assert scene_hex_sphere_.lights[0].direction == (1, 0, 0)
     assert scene_hex_sphere_.lights[0].color == (0.5, 0.5, 0.5)
 
-    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100)
+    buf_proxy = fresnel.preview(scene_hex_sphere_, w=100, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_scene.test_light_dir.png', 'wb'), 'png');
@@ -64,7 +64,7 @@ def test_multiple_geometries(device_, generate=False):
     geom2 = fresnel.geometry.Sphere(scene, position = [[4, 1, 0], [4, -1, 0], [2, 1, 0], [2, -1, 0]], radius=1.0)
     geom2.material = fresnel.material.Material(solid=0.0, color=fresnel.color.linear([1,0.874,0.169]))
 
-    buf_proxy = fresnel.preview(scene, w=200, h=100)
+    buf_proxy = fresnel.preview(scene, w=200, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_scene.test_multiple_geometries1.png', 'wb'), 'png');
@@ -73,7 +73,7 @@ def test_multiple_geometries(device_, generate=False):
 
     geom1.disable()
 
-    buf_proxy = fresnel.preview(scene, w=200, h=100)
+    buf_proxy = fresnel.preview(scene, w=200, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_scene.test_multiple_geometries2.png', 'wb'), 'png');
@@ -82,7 +82,7 @@ def test_multiple_geometries(device_, generate=False):
 
     geom1.enable()
 
-    buf_proxy = fresnel.preview(scene, w=200, h=100)
+    buf_proxy = fresnel.preview(scene, w=200, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_scene.test_multiple_geometries3.png', 'wb'), 'png');
@@ -91,7 +91,7 @@ def test_multiple_geometries(device_, generate=False):
 
     geom2.remove()
 
-    buf_proxy = fresnel.preview(scene, w=200, h=100)
+    buf_proxy = fresnel.preview(scene, w=200, h=100, anti_alias=False)
 
     if generate:
         PIL.Image.fromarray(buf_proxy[:], mode='RGBA').save(open('output/test_scene.test_multiple_geometries4.png', 'wb'), 'png');

--- a/test/test_tracer_direct.py
+++ b/test/test_tracer_direct.py
@@ -9,7 +9,7 @@ import pathlib
 dir_path = pathlib.Path(os.path.realpath(__file__)).parent
 
 def test_render(scene_hex_sphere_, generate=False):
-    tracer = fresnel.tracer.Preview(device=scene_hex_sphere_.device, w=100, h=100)
+    tracer = fresnel.tracer.Preview(device=scene_hex_sphere_.device, w=100, h=100, anti_alias=False)
     buf = tracer.output[:]
     assert buf.shape == (100,100,4)
 
@@ -21,7 +21,7 @@ def test_render(scene_hex_sphere_, generate=False):
         conftest.assert_image_approx_equal(buf_proxy[:], dir_path / 'reference' / 'test_tracer_direct.test_render.png')
 
 def test_render_aa(scene_hex_sphere_, generate=False):
-    tracer = fresnel.tracer.Preview(device=scene_hex_sphere_.device, w=100, h=100, aa_level=3)
+    tracer = fresnel.tracer.Preview(device=scene_hex_sphere_.device, w=100, h=100, anti_alias=True)
     buf = tracer.output[:]
     assert buf.shape == (100,100,4)
 
@@ -33,7 +33,7 @@ def test_render_aa(scene_hex_sphere_, generate=False):
         conftest.assert_image_approx_equal(buf_proxy[:], dir_path / 'reference' / 'test_tracer_direct.test_render_aa.png')
 
 def test_resize(scene_hex_sphere_, generate=False):
-    tracer = fresnel.tracer.Preview(device=scene_hex_sphere_.device, w=100, h=100)
+    tracer = fresnel.tracer.Preview(device=scene_hex_sphere_.device, w=100, h=100, anti_alias=False)
     buf = tracer.output[:]
     assert buf.shape == (100,100,4)
 


### PR DESCRIPTION
## Description
Replace aa_level (int) with anti_alias (bool default to True).

<!-- Describe your changes in detail. -->
For previews, users will probably prefer to wait for the extra time for a smoother image, so the default is now true.
If set, the level is now an 8x8 subpixel grid.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #74 

## Preview

<!-- Link to or attach a file that demonstrates the change (if applicable). -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
1. Updated tracer.py and __init__.py
2. Updated docstrings

```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
