### PR TITLE
Add signal to SceneView Widget

### DIFF
--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -335,4 +335,3 @@ class SceneView(QWidget):
                                     & QtCore.Qt.ControlModifier)
         self._start_rendering()
         event.accept()
-

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -185,6 +185,7 @@ class SceneView(QWidget):
 
         - :doc:`examples/02-Advanced-topics/03-Interactive-scene-view`
     """
+
     def __init__(self, scene, max_samples=2000):
         super().__init__()
         self.setWindowTitle("fresnel: scene viewer")
@@ -221,10 +222,6 @@ class SceneView(QWidget):
 
         # send signal when rendering starts
         self.re = RenderEvent()
-        self.re.update_signal.connect(self._test)
-
-    def _test(self, camera):
-        print("camera:", camera.position)
 
     def minimumSizeHint(self):  # noqa
         return QtCore.QSize(1610, 1000)

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -19,7 +19,6 @@ from PySide2 import QtGui
 from PySide2 import QtCore
 from PySide2 import QtWidgets
 import math
-#import numpy as np
 
 from . import tracer, camera
 
@@ -186,7 +185,6 @@ class SceneView(QWidget):
 
         - :doc:`examples/02-Advanced-topics/03-Interactive-scene-view`
     """
-
     def __init__(self, scene, max_samples=2000):
         super().__init__()
         self.setWindowTitle("fresnel: scene viewer")
@@ -220,6 +218,13 @@ class SceneView(QWidget):
 
         self.camera_controller = _CameraController3D(self._scene.camera)
         self.ipython_display_formatter = 'text'
+
+        # send signal when rendering starts
+        self.re = RenderEvent()
+        self.re.update_signal.connect(self._test)
+
+    def _test(self, camera):
+        print("camera:", camera.position)
 
     def minimumSizeHint(self):  # noqa
         return QtCore.QSize(1610, 1000)
@@ -279,6 +284,7 @@ class SceneView(QWidget):
         self.rendering = False
 
     def _start_rendering(self):
+        self.re.update_signal.emit(self._scene.camera)
         self.rendering = True
         self.samples = 0
         self.tracer.reset()
@@ -332,3 +338,6 @@ class SceneView(QWidget):
                                     & QtCore.Qt.ControlModifier)
         self._start_rendering()
         event.accept()
+
+class RenderEvent(QtCore.QObject):
+    update_signal = QtCore.Signal(camera.Camera)

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -185,6 +185,8 @@ class SceneView(QWidget):
         - :doc:`examples/02-Advanced-topics/03-Interactive-scene-view`
     """
 
+    update_signal = QtCore.Signal(camera.Camera)
+
     def __init__(self, scene, max_samples=2000):
         super().__init__()
         self.setWindowTitle("fresnel: scene viewer")
@@ -219,8 +221,8 @@ class SceneView(QWidget):
         self.camera_controller = _CameraController3D(self._scene.camera)
         self.ipython_display_formatter = 'text'
 
-        # initialize QObject for sending signals
-        self.re = RenderEvent()
+        # test
+        self.update_signal.connect(self._test)
 
     def minimumSizeHint(self):  # noqa
         return QtCore.QSize(1610, 1000)
@@ -281,12 +283,15 @@ class SceneView(QWidget):
 
     def _start_rendering(self):
         # send signal
-        self.re.update_signal.emit(self._scene.camera)
+        self.update_signal.emit(self._scene.camera)
 
         self.rendering = True
         self.samples = 0
         self.tracer.reset()
         self.repaint_timer.start()
+
+    def _test(self, camera):
+        print("camera:", camera.position)
 
     def mouseMoveEvent(self, event):  # noqa
         delta = event.pos() - self.mouse_initial_pos
@@ -337,5 +342,3 @@ class SceneView(QWidget):
         self._start_rendering()
         event.accept()
 
-class RenderEvent(QtCore.QObject):
-    update_signal = QtCore.Signal(camera.Camera)

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -52,7 +52,6 @@ def _q_conjugate(q):
 
 
 def _qv_mult(q1, v1):
-    #q2 = np.append(np.array([0]), v1)
     q2 = (0.0,) + v1
     return _q_mult(_q_mult(q1, q2), _q_conjugate(q1))[1:]
 
@@ -220,7 +219,7 @@ class SceneView(QWidget):
         self.camera_controller = _CameraController3D(self._scene.camera)
         self.ipython_display_formatter = 'text'
 
-        # send signal when rendering starts
+        # initialize QObject for sending signals
         self.re = RenderEvent()
 
     def minimumSizeHint(self):  # noqa
@@ -281,7 +280,9 @@ class SceneView(QWidget):
         self.rendering = False
 
     def _start_rendering(self):
+        # send signal
         self.re.update_signal.emit(self._scene.camera)
+
         self.rendering = True
         self.samples = 0
         self.tracer.reset()

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -185,7 +185,7 @@ class SceneView(QWidget):
         - :doc:`examples/02-Advanced-topics/03-Interactive-scene-view`
     """
 
-    update_signal = QtCore.Signal(camera.Camera)
+    rendering = QtCore.Signal(camera.Camera)
 
     def __init__(self, scene, max_samples=2000):
         super().__init__()

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -221,9 +221,6 @@ class SceneView(QWidget):
         self.camera_controller = _CameraController3D(self._scene.camera)
         self.ipython_display_formatter = 'text'
 
-        # test
-        self.update_signal.connect(self._test)
-
     def minimumSizeHint(self):  # noqa
         return QtCore.QSize(1610, 1000)
 
@@ -289,9 +286,6 @@ class SceneView(QWidget):
         self.samples = 0
         self.tracer.reset()
         self.repaint_timer.start()
-
-    def _test(self, camera):
-        print("camera:", camera.position)
 
     def mouseMoveEvent(self, event):  # noqa
         delta = event.pos() - self.mouse_initial_pos

--- a/fresnel/interact.py
+++ b/fresnel/interact.py
@@ -19,13 +19,14 @@ from PySide2 import QtGui
 from PySide2 import QtCore
 from PySide2 import QtWidgets
 import math
+#import numpy as np
 
 from . import tracer, camera
 
 # initialize QApplication
 # but not in sphinx
 if 'sphinx' not in sys.modules:
-    import PySide2.QtWidgets.QWidget as QWidget
+    from PySide2.QtWidgets import QWidget
 
     app = QtCore.QCoreApplication.instance()
     if app is None:
@@ -52,6 +53,7 @@ def _q_conjugate(q):
 
 
 def _qv_mult(q1, v1):
+    #q2 = np.append(np.array([0]), v1)
     q2 = (0.0,) + v1
     return _q_mult(_q_mult(q1, q2), _q_conjugate(q1))[1:]
 

--- a/fresnel/material.py
+++ b/fresnel/material.py
@@ -4,7 +4,7 @@
 
 """Materials describe the way light interacts with surfaces."""
 
-from fresnel import _common
+from . import _common
 
 
 class Material(object):


### PR DESCRIPTION
## Description

I added a signal that is emitted when the widget starts rendering. This is useful to me for connecting it to another widget.

Resolves: https://github.com/cmelab/GIXStapose/issues/5

## Preview

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
