### PR TITLE
Add Mesh to documentation summary box.

### DIFF
--- a/doc/module-geometry.rst
+++ b/doc/module-geometry.rst
@@ -16,6 +16,7 @@ fresnel.geometry
     ConvexPolyhedron
     Cylinder
     Geometry
+    Mesh
     Polygon
     Sphere
 


### PR DESCRIPTION
## Description

Adds `Mesh` to the documentation summary.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
