### PR TITLE
Only build HTML docs.

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -13,7 +13,8 @@ submodules:
     include: all
     recursive: true
 
-formats: all
+formats:
+    - htmlzip
 
 build:
   image: stable


### PR DESCRIPTION
## Description

Removes LaTeX documentation formats to fix the build error shown here:
https://readthedocs.org/projects/fresnel/builds/14294098/

Similar PR to coxeter: https://github.com/glotzerlab/coxeter/pull/157

## Motivation and context

Fixes ReadTheDocs build.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
