### PR TITLE
Revert to matrix in single workflow file.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,116 +1,100 @@
-name: Build
+# name: Build
 
-on:
-  workflow_call:
-    inputs:
-      repository:
-        type: string
-        required: false
-        default: "glotzerlab"
-      image:
-        type: string
-        required: true
-      build_runner:
-        type: string
-        required: false
-        default: ubuntu-latest
-      test_runner:
-        type: string
-        required: false
-        default: ubuntu-latest
-      test_docker_options:
-        type: string
-        required: false
-      render_gallery:
-        type: boolean
-        required: false
-        default: false
+# on:
+#   workflow_call:
+#     inputs:
+#       matrix:
+#         type: string
+#         required: true
 
-    secrets:
-      DOCKER_HUB_USERNAME:
-        required: true
-      DOCKER_HUB_ACCESS_TOKEN:
-        required: true
+#     secrets:
+#       DOCKER_HUB_USERNAME:
+#         required: true
+#       DOCKER_HUB_ACCESS_TOKEN:
+#         required: true
 
-# Use multiple jobs to reduce the amount of time spent on GPU runners. Use GitHub Hosted runners
-# for compiling all tests configurations (GPU and CPU), then upload the installation directory
-# as an artifact. Test jobs depend on the build job, download the install directory, and run the
-# tests. Upload each build configuration to a separate artifact.
+# # Use multiple jobs to reduce the amount of time spent on GPU runners. Use GitHub Hosted runners
+# # for compiling all tests configurations (GPU and CPU), then upload the installation directory
+# # as an artifact. Test jobs depend on the build job, download the install directory, and run the
+# # tests. Upload each build configuration to a separate artifact.
 
-jobs:
-  build:
-    runs-on: ${{ inputs.build_runner }}
-    container:
-      image: ${{ inputs.repository }}/ci:2022.01-${{ inputs.image }}
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+# # Pass matrix parameters following the strategy here: https://github.community/t/reusable-workflow-with-strategy-matrix/205676
 
-    steps:
-    - uses: actions/checkout@v2.4.0
-      with:
-        path: code
-        submodules: true
-    - name: Configure
-      run: |
-        mkdir -p build
-        cd build
-        cmake ../code -GNinja \
-                      -DENABLE_EMBREE=${ENABLE_EMBREE:-"ON"} \
-                      -DENABLE_OPTIX=${ENABLE_OPTIX:-"OFF"} \
-                      -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
-      env:
-        ENABLE_OPTIX: ${{ contains(inputs.image, 'optix') }}
-        ENABLE_EMBREE: ${{ !contains(inputs.image, 'optix') }}
-    - name: Build
-      run: ninja install
-      working-directory: build
-   # Tar the installation directory to preserve permissions and reduce HTTP requests on upload.
-    - name: 'Tar install'
-      run: tar --use-compress-program='zstd -10 -T0' -cvf install.tar install
-    # Upload the tarball. Retain the file for a limited time in case developers need to download
-    # and run tests locally for further debugging.
-    - uses: actions/upload-artifact@v2.2.4
-      name: 'Upload install'
-      with:
-        name: install-${{ inputs.image }}-${{ github.sha }}
-        path: install.tar
-        retention-days: 7
+# jobs:
+#   build:
+#     name: Build [${{ matrix.image }}]
+#     runs-on: ubuntu-latest
+#     container:
+#       image: ${{ matrix.repository }}/ci:2022.01-${{ matrix.image }}
+#       credentials:
+#         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+#         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  test:
-    needs: build
-    runs-on: ${{ inputs.test_runner }}
-    container:
-      image: ${{ inputs.repository }}/ci:2022.01-${{ inputs.image }}
-      options: ${{ inputs.test_docker_options }} -e CUDA_VISIBLE_DEVICES
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+#     steps:
+#     - uses: actions/checkout@v2.4.0
+#       with:
+#         path: code
+#         submodules: true
+#     - name: Configure
+#       run: |
+#         mkdir -p build
+#         cd build
+#         cmake ../code -GNinja \
+#                       -DENABLE_EMBREE=${ENABLE_EMBREE:-"ON"} \
+#                       -DENABLE_OPTIX=${ENABLE_OPTIX:-"OFF"} \
+#                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
+#       env:
+#         ENABLE_OPTIX: ${{ contains(matrix.image, 'optix') }}
+#         ENABLE_EMBREE: ${{ !contains(matrix.image, 'optix') }}
+#     - name: Build
+#       run: ninja install
+#       working-directory: build
+#    # Tar the installation directory to preserve permissions and reduce HTTP requests on upload.
+#     - name: 'Tar install'
+#       run: tar --use-compress-program='zstd -10 -T0' -cvf install.tar install
+#     # Upload the tarball. Retain the file for a limited time in case developers need to download
+#     # and run tests locally for further debugging.
+#     - uses: actions/upload-artifact@v2.2.4
+#       name: 'Upload install'
+#       with:
+#         name: install-${{ matrix.image }}-${{ github.sha }}
+#         path: install.tar
+#         retention-days: 7
 
-    steps:
-    - name: Clean workspace
-      run: rm -rf ./*
+#   test:
+#     needs: build
+#     runs-on: ${{ matrix.test_runner }}
+#     container:
+#       image: ${{ matrix.repository }}/ci:2022.01-${{ matrix.image }}
+#       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
+#       credentials:
+#         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+#         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-    - uses: actions/download-artifact@v2.0.10
-      with:
-        name: install-${{ inputs.image }}-${{ github.sha }}
-    - name: Untar install
-      run: tar --use-compress-program='zstd -10 -T0' -xvf install.tar
+#     steps:
+#     - name: Clean workspace
+#       run: rm -rf ./*
 
-    - name: Run tests
-      run: python3 -m pytest --pyargs fresnel -v --log-level=DEBUG --durations=0 --durations-min=0.1
-      env:
-        PYTHONPATH: ${{ github.workspace }}/install
+#     - uses: actions/download-artifact@v2.0.10
+#       with:
+#         name: install-${{ matrix.image }}-${{ github.sha }}
+#     - name: Untar install
+#       run: tar --use-compress-program='zstd -10 -T0' -xvf install.tar
 
-    - uses: actions/checkout@v2.4.0
-      if: ${{ inputs.render_gallery }}
-      with:
-        submodules: true
-        path: code
+#     - name: Run tests
+#       run: python3 -m pytest --pyargs fresnel -v --log-level=DEBUG --durations=0 --durations-min=0.1
+#       env:
+#         PYTHONPATH: ${{ github.workspace }}/install
 
-    - name: Render gallery images
-      if: ${{ inputs.render_gallery }}
-      run: for i in *.py; do echo "Rendering $i" && python3 $i || exit 1; done
-      working-directory: code/doc/gallery
-      env:
-        PYTHONPATH: ${{ github.workspace }}/install
+#     - uses: actions/checkout@v2.4.0
+#       if: ${{ matrix.render_gallery }}
+#       with:
+#         submodules: true
+#         path: code
+
+#     - name: Render gallery images
+#       if: ${{ matrix.render_gallery }}
+#       run: for i in *.py; do echo "Rendering $i" && python3 $i || exit 1; done
+#       working-directory: code/doc/gallery
+#       env:
+#         PYTHONPATH: ${{ github.workspace }}/install

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -5,117 +5,134 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  # # Trigger on pull requests.
-  # pull_request:
+  # Trigger on pull requests.
+  pull_request:
 
-  # # Trigger on pushes to the mainline branches. This prevents building commits twice when the pull
-  # # request source branch is in the same repository.
-  # push:
-  #   branches:
-  #   - "master"
-
-  # pull request triggers are break reusable workflows: https://github.community/t/ref-head-in-reusable-workflows/203690
+  # Trigger on pushes to the mainline branches. This prevents building commits twice when the pull
+  # request source branch is in the same repository.
   push:
+    branches:
+    - "master"
 
   # Trigger on request.
   workflow_dispatch:
 
+# Use multiple jobs to reduce the amount of time spent on GPU runners. Use GitHub Hosted runners
+# for compiling all tests configurations (GPU and CPU), then upload the installation directory
+# as an artifact. Test jobs depend on the build job, download the install directory, and run the
+# tests. Upload each build configuration to a separate artifact.
+
+# Copy and paste the matrix from `build_linux` to `test_linux`. The list in `test_linux` must be a
+# subset of the list in `build_linux`.
+
 jobs:
-  clang13_py310:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: clang13_py310
-      render_gallery: true
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  build_linux:
+    name: Build [${{ matrix.image }}]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.repository }}/ci:2022.01-${{ matrix.image }}
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  clang12_py310:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: clang12_py310
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    strategy:
+      matrix:
+        include:
+        - {repository: glotzerlab, image: clang13_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
+        - {repository: glotzerlab, image: clang12_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: clang11_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc10_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc9_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc8_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: clang6_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc7_py36, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: joaander, image: optix60_cuda11_py38, test_runner: [self-hosted,GPU], test_docker_options: '--mount type=bind,source=/usr/lib/libnvidia-rtcore.so,target=/usr/lib/libnvidia-rtcore.so --mount type=bind,source=/usr/lib/libnvoptix.so,target=/usr/lib/libnvoptix.so --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl --gpus=all', render_gallery: true }
+        - {repository: joaander, image: optix60_cuda10_py37, test_runner: [self-hosted,GPU], test_docker_options: '--mount type=bind,source=/usr/lib/libnvidia-rtcore.so,target=/usr/lib/libnvidia-rtcore.so --mount type=bind,source=/usr/lib/libnvoptix.so,target=/usr/lib/libnvoptix.so --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl --gpus=all', render_gallery: false }
 
-  gcc11_py310:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: gcc11_py310
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2.4.0
+      with:
+        path: code
+        submodules: true
+    - name: Configure
+      run: |
+        mkdir -p build
+        cd build
+        cmake ../code -GNinja \
+                      -DENABLE_EMBREE=${ENABLE_EMBREE:-"ON"} \
+                      -DENABLE_OPTIX=${ENABLE_OPTIX:-"OFF"} \
+                      -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
+      env:
+        ENABLE_OPTIX: ${{ contains(matrix.image, 'optix') }}
+        ENABLE_EMBREE: ${{ !contains(matrix.image, 'optix') }}
+    - name: Build
+      run: ninja install
+      working-directory: build
+   # Tar the installation directory to preserve permissions and reduce HTTP requests on upload.
+    - name: 'Tar install'
+      run: tar --use-compress-program='zstd -10 -T0' -cvf install.tar install
+    # Upload the tarball. Retain the file for a limited time in case developers need to download
+    # and run tests locally for further debugging.
+    - uses: actions/upload-artifact@v2.2.4
+      name: 'Upload install'
+      with:
+        name: install-${{ matrix.image }}-${{ github.sha }}
+        path: install.tar
+        retention-days: 7
 
-  clang11_py39:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: clang11_py39
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  test_linux:
+    needs: build_linux
+    runs-on: ${{ matrix.test_runner }}
+    container:
+      image: ${{ matrix.repository }}/ci:2022.01-${{ matrix.image }}
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  gcc10_py39:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: gcc10_py39
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    strategy:
+      matrix:
+        include:
+        - {repository: glotzerlab, image: clang13_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
+        - {repository: glotzerlab, image: clang12_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: clang11_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc10_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc9_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc8_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: clang6_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc7_py36, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: joaander, image: optix60_cuda11_py38, test_runner: [self-hosted,GPU], test_docker_options: '--mount type=bind,source=/usr/lib/libnvidia-rtcore.so,target=/usr/lib/libnvidia-rtcore.so --mount type=bind,source=/usr/lib/libnvoptix.so,target=/usr/lib/libnvoptix.so --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl --gpus=all', render_gallery: true }
+        - {repository: joaander, image: optix60_cuda10_py37, test_runner: [self-hosted,GPU], test_docker_options: '--mount type=bind,source=/usr/lib/libnvidia-rtcore.so,target=/usr/lib/libnvidia-rtcore.so --mount type=bind,source=/usr/lib/libnvoptix.so,target=/usr/lib/libnvoptix.so --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl --gpus=all', render_gallery: false }
 
-  gcc9_py38:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: gcc9_py38
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    steps:
+    - name: Clean workspace
+      run: rm -rf ./*
 
-  gcc8_py37:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: gcc8_py37
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - uses: actions/download-artifact@v2.0.10
+      with:
+        name: install-${{ matrix.image }}-${{ github.sha }}
+    - name: Untar install
+      run: tar --use-compress-program='zstd -10 -T0' -xvf install.tar
 
-  clang6_py37:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: clang6_py37
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - name: Run tests
+      run: python3 -m pytest --pyargs fresnel -v --log-level=DEBUG --durations=0 --durations-min=0.1
+      env:
+        PYTHONPATH: ${{ github.workspace }}/install
 
-  gcc7_py36:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: gcc7_py36
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - uses: actions/checkout@v2.4.0
+      if: ${{ matrix.render_gallery }}
+      with:
+        submodules: true
+        path: code
 
-  optix60_cuda11_py38:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: optix60_cuda11_py38
-      repository: joaander
-      test_runner: self-hosted
-      test_docker_options: --mount type=bind,source=/usr/lib/libnvidia-rtcore.so,target=/usr/lib/libnvidia-rtcore.so --mount type=bind,source=/usr/lib/libnvoptix.so,target=/usr/lib/libnvoptix.so --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl --gpus=all
-      render_gallery: true
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-  optix60_cuda10_py37:
-    uses: ./.github/workflows/build_test.yml
-    with:
-      image: optix60_cuda10_py37
-      repository: joaander
-      test_runner: self-hosted
-      test_docker_options: --mount type=bind,source=/usr/lib/libnvidia-rtcore.so,target=/usr/lib/libnvidia-rtcore.so --mount type=bind,source=/usr/lib/libnvoptix.so,target=/usr/lib/libnvoptix.so --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl --gpus=all
-    secrets:
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - name: Render gallery images
+      if: ${{ matrix.render_gallery }}
+      run: for i in *.py; do echo "Rendering $i" && python3 $i || exit 1; done
+      working-directory: code/doc/gallery
+      env:
+        PYTHONPATH: ${{ github.workspace }}/install
 
   build_test_windows:
     name: Build and test on ${{ matrix.os }}
@@ -177,18 +194,7 @@ jobs:
   # This job is used to provide a single requirement for branch merge conditions.
   tests_complete:
     name: Unit test
-    needs: [clang13_py310,
-            clang12_py310,
-            gcc11_py310,
-            clang11_py39,
-            gcc10_py39,
-            gcc9_py38,
-            gcc8_py37,
-            clang6_py37,
-            gcc7_py36,
-            optix60_cuda11_py38,
-            optix60_cuda10_py37,
-            build_test_windows]
+    needs: [build_linux, test_linux, build_test_windows]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Revert back to a single workflow file and have developers manually copy and paste. GH actions doesn't even allow the matrix to reference variables.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Reusable workflows are too buggy to use. 

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
