### PR TITLE
Add support for Embree 4.0.0.

### DIFF
--- a/.github/workflows/environments/conda.yml
+++ b/.github/workflows/environments/conda.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - tbb=2021.7.0
 - tbb-devel=2021.7.0
-- embree3=3.13.5
+- embree=4.0.0
 - pybind11=2.10
 - numpy=1.24
 - pillow=9.4

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -8,7 +8,7 @@ To build the **fresnel** Python package from source:
 
 1. `Install prerequisites`_::
 
-   $ <package-manager> install cmake git python numpy pybind11 qhull embree3
+   $ <package-manager> install cmake git python numpy pybind11 qhull embree
    $ <package-manager> install pillow pytest
 
 2. `Obtain the source`_::
@@ -75,7 +75,7 @@ Install prerequisites
 - For CPU execution (required when ``ENABLE_EMBREE=ON``):
 
   - Intel TBB >= 4.3.20150611
-  - Intel Embree >= 3.0.0
+  - Intel Embree >= 4.0.0
 
 - For GPU execution (required when ``ENABLE_OPTIX=ON``):
 

--- a/CMake/Findembree.cmake
+++ b/CMake/Findembree.cmake
@@ -1,10 +1,10 @@
-find_path(EMBREE_INCLUDE_DIR embree3/rtcore.h)
+find_path(EMBREE_INCLUDE_DIR embree4/rtcore.h)
 
-find_library(EMBREE_LIBRARY embree3
+find_library(EMBREE_LIBRARY embree4
              HINTS ${EMBREE_INCLUDE_DIR}/../lib )
 
-if(EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h")
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" EMBREE_H REGEX "^#define EMBREE_VERSION_.*$")
+if(EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_INCLUDE_DIR}/embree4/rtcore_version.h")
+    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree4/rtcore_version.h" EMBREE_H REGEX "^#define EMBREE_VERSION_.*$")
     string(REGEX REPLACE ".*#define EMBREE_VERSION_MAJOR ([0-9]+).*$" "\\1" EMBREE_VERSION_MAJOR "${EMBREE_H}")
     string(REGEX REPLACE "^.*EMBREE_VERSION_MINOR ([0-9]+).*$" "\\1" EMBREE_VERSION_MINOR  "${EMBREE_H}")
     string(REGEX REPLACE "^.*EMBREE_VERSION_PATCH ([0-9]+).*$" "\\1" EMBREE_VERSION_PATCH  "${EMBREE_H}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ include_directories(${pybind11_INCLUDE_DIR})
 option(ENABLE_EMBREE "Use Embree for ray tracing on the CPU" ON)
 
 if (ENABLE_EMBREE)
-    find_package_config_first(embree 3.0)
+    find_package_config_first(embree 4.0)
     if (embree_FOUND)
         find_package_message(embree "Found embree: ${embree_DIR} ${EMBREE_LIBRARY} ${EMBREE_INCLUDE_DIRS}" "[${EMBREE_LIBRARY}][${EMBREE_INCLUDE_DIRS}]")
     endif()

--- a/fresnel.code-workspace
+++ b/fresnel.code-workspace
@@ -6,7 +6,8 @@
     ],
     "settings": {
         "files.associations": {
-            "**/.azp/**/*.yml": "azure-pipelines"
+            "**/.azp/**/*.yml": "azure-pipelines",
+            "limits": "cpp"
         },
     },
 }

--- a/fresnel/cpu/Device.h
+++ b/fresnel/cpu/Device.h
@@ -6,8 +6,8 @@
 
 #include "embree_platform.h"
 #include "tbb/task_arena.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/pybind11.h>
 #include <stdexcept>
 

--- a/fresnel/cpu/Geometry.cc
+++ b/fresnel/cpu/Geometry.cc
@@ -4,7 +4,7 @@
 #include <stdexcept>
 
 #include "Geometry.h"
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 
 namespace fresnel
     {

--- a/fresnel/cpu/Geometry.h
+++ b/fresnel/cpu/Geometry.h
@@ -5,8 +5,8 @@
 #define GEOMETRY_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/pybind11.h>
 
 #include "Scene.h"

--- a/fresnel/cpu/GeometryConvexPolyhedron.cc
+++ b/fresnel/cpu/GeometryConvexPolyhedron.cc
@@ -139,6 +139,8 @@ void GeometryConvexPolyhedron::bounds(const struct RTCBoundsFunctionArguments* a
 */
 void GeometryConvexPolyhedron::intersect(const struct RTCIntersectFunctionNArguments* args)
     {
+    *args->valid = 0;
+
     GeometryConvexPolyhedron* geom = (GeometryConvexPolyhedron*)args->geometryUserPtr;
 
     // adapted from OptiX quick start tutorial and Embree user_geometry tutorial files
@@ -328,6 +330,7 @@ void GeometryConvexPolyhedron::intersect(const struct RTCIntersectFunctionNArgum
                 }
             }
         context.d = min_d;
+        *args->valid = -1;
         }
     }
 

--- a/fresnel/cpu/GeometryConvexPolyhedron.h
+++ b/fresnel/cpu/GeometryConvexPolyhedron.h
@@ -5,8 +5,8 @@
 #define GEOMETRY_CONVEX_POLYHEDRON_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 

--- a/fresnel/cpu/GeometryCylinder.cc
+++ b/fresnel/cpu/GeometryCylinder.cc
@@ -75,6 +75,8 @@ void GeometryCylinder::bounds(const struct RTCBoundsFunctionArguments* args)
 */
 void GeometryCylinder::intersect(const struct RTCIntersectFunctionNArguments* args)
     {
+    *args->valid = 0;
+
     GeometryCylinder* geom = (GeometryCylinder*)args->geometryUserPtr;
     const vec3<float> A = geom->m_points->get(args->primID * 2 + 0);
     const vec3<float> B = geom->m_points->get(args->primID * 2 + 1);
@@ -111,6 +113,7 @@ void GeometryCylinder::intersect(const struct RTCIntersectFunctionNArguments* ar
         rayhit.hit.instID[0] = context.context.instID[0];
         context.shading_color = geom->m_color->get(args->primID * 2 + color_index);
         context.d = d;
+        *args->valid = -1;
         }
     }
 

--- a/fresnel/cpu/GeometryCylinder.h
+++ b/fresnel/cpu/GeometryCylinder.h
@@ -5,8 +5,8 @@
 #define GEOMETRY_CYLINDER_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 
 #include <pybind11/pybind11.h>
 

--- a/fresnel/cpu/GeometryMesh.cc
+++ b/fresnel/cpu/GeometryMesh.cc
@@ -114,6 +114,8 @@ void GeometryMesh::bounds(const struct RTCBoundsFunctionArguments* args)
 */
 void GeometryMesh::intersect(const struct RTCIntersectFunctionNArguments* args)
     {
+    *args->valid = 0;
+
     GeometryMesh* geom = (GeometryMesh*)args->geometryUserPtr;
 
     unsigned int item = args->primID;
@@ -185,6 +187,7 @@ void GeometryMesh::intersect(const struct RTCIntersectFunctionNArguments* args)
                                 + geom->m_color->get(i_face * 3 + 2) * w;
 
         context.d = d;
+        *args->valid = -1;
         }
     }
 

--- a/fresnel/cpu/GeometryMesh.h
+++ b/fresnel/cpu/GeometryMesh.h
@@ -5,8 +5,8 @@
 #define GEOMETRY_MESH_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 

--- a/fresnel/cpu/GeometryPolygon.cc
+++ b/fresnel/cpu/GeometryPolygon.cc
@@ -149,6 +149,8 @@ inline bool is_inside(float& min_d, const vec2<float>& p, const std::vector<vec2
 */
 void GeometryPolygon::intersect(const struct RTCIntersectFunctionNArguments* args)
     {
+    *args->valid = 0;
+
     GeometryPolygon* geom = (GeometryPolygon*)args->geometryUserPtr;
 
     const vec2<float> p2 = geom->m_position->get(args->primID);
@@ -225,6 +227,7 @@ void GeometryPolygon::intersect(const struct RTCIntersectFunctionNArguments* arg
         rh.hit.Ng_z = Ng.z;
         context.shading_color = geom->m_color->get(args->primID);
         context.d = min_d;
+        *args->valid = -1;
         }
     }
 

--- a/fresnel/cpu/GeometryPolygon.h
+++ b/fresnel/cpu/GeometryPolygon.h
@@ -5,8 +5,8 @@
 #define GEOMETRY_POLYGON_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 

--- a/fresnel/cpu/GeometrySphere.cc
+++ b/fresnel/cpu/GeometrySphere.cc
@@ -80,6 +80,8 @@ void GeometrySphere::bounds(const struct RTCBoundsFunctionArguments* args)
 */
 void GeometrySphere::intersect(const struct RTCIntersectFunctionNArguments* args)
     {
+    *args->valid = 0;
+
     GeometrySphere* geom = (GeometrySphere*)args->geometryUserPtr;
     const vec3<float> position = geom->m_position->get(args->primID);
     const float radius = geom->m_radius->get(args->primID);
@@ -110,6 +112,7 @@ void GeometrySphere::intersect(const struct RTCIntersectFunctionNArguments* args
         rayhit.hit.instID[0] = context.context.instID[0];
         context.shading_color = geom->m_color->get(args->primID);
         context.d = d;
+        *args->valid = -1;
         }
     }
 

--- a/fresnel/cpu/GeometrySphere.h
+++ b/fresnel/cpu/GeometrySphere.h
@@ -5,8 +5,8 @@
 #define GEOMETRY_SPHERE_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 
 #include <pybind11/pybind11.h>
 

--- a/fresnel/cpu/Scene.h
+++ b/fresnel/cpu/Scene.h
@@ -5,8 +5,8 @@
 #define SCENE_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/pybind11.h>
 
 #include "Device.h"

--- a/fresnel/cpu/Tracer.h
+++ b/fresnel/cpu/Tracer.h
@@ -5,8 +5,8 @@
 #define TRACER_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/pybind11.h>
 
 #include "Array.h"

--- a/fresnel/cpu/TracerDirect.cc
+++ b/fresnel/cpu/TracerDirect.cc
@@ -107,9 +107,14 @@ void TracerDirect::renderImplementation(std::shared_ptr<Scene> scene)
                             ray_hit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
 
                             FresnelRTCIntersectContext context;
-                            rtcInitIntersectContext(&context.context);
+                            rtcInitRayQueryContext(&context.context);
 
-                            rtcIntersect1(scene->getRTCScene(), &context.context, &ray_hit);
+                            RTCIntersectArguments args;
+                            rtcInitIntersectArguments(&args);
+                            args.flags = RTC_RAY_QUERY_FLAG_COHERENT;
+                            args.context = &context.context;
+
+                            rtcIntersect1(scene->getRTCScene(), &ray_hit, &args);
 
                             // determine the output pixel color
                             RGB<float> c = background_color;

--- a/fresnel/cpu/TracerDirect.h
+++ b/fresnel/cpu/TracerDirect.h
@@ -5,8 +5,8 @@
 #define TRACER_WHITTED_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/pybind11.h>
 
 #include "Tracer.h"

--- a/fresnel/cpu/TracerPath.cc
+++ b/fresnel/cpu/TracerPath.cc
@@ -127,9 +127,13 @@ void TracerPath::renderImplementation(std::shared_ptr<Scene> scene)
                         ray_hit_initial.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
 
                         FresnelRTCIntersectContext context;
-                        rtcInitIntersectContext(&context.context);
+                        rtcInitRayQueryContext(&context.context);
 
-                        rtcIntersect1(scene->getRTCScene(), &context.context, &ray_hit_initial);
+                        RTCIntersectArguments args_initial;
+                        rtcInitIntersectArguments(&args_initial);
+                        args_initial.flags = RTC_RAY_QUERY_FLAG_COHERENT;
+                        args_initial.context = &context.context;
+                        rtcIntersect1(scene->getRTCScene(), &ray_hit_initial, &args_initial);
 
                         FresnelRTCIntersectContext context_initial = context;
 
@@ -170,9 +174,14 @@ void TracerPath::renderImplementation(std::shared_ptr<Scene> scene)
 
                                     // subsequent depth steps need to trace
                                     context = FresnelRTCIntersectContext();
-                                    rtcInitIntersectContext(&context.context);
+                                    rtcInitRayQueryContext(&context.context);
 
-                                    rtcIntersect1(scene->getRTCScene(), &context.context, &ray_hit);
+                                    RTCIntersectArguments args;
+                                    rtcInitIntersectArguments(&args);
+                                    args.flags = RTC_RAY_QUERY_FLAG_INCOHERENT;
+                                    args.context = &context.context;
+
+                                    rtcIntersect1(scene->getRTCScene(), &ray_hit, &args);
                                     }
 
                                 if (ray_hit.hit.geomID != RTC_INVALID_GEOMETRY_ID)

--- a/fresnel/cpu/TracerPath.h
+++ b/fresnel/cpu/TracerPath.h
@@ -5,8 +5,8 @@
 #define TRACER_PATH_H_
 
 #include "embree_platform.h"
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 #include <pybind11/pybind11.h>
 
 #include "Tracer.h"

--- a/fresnel/cpu/embree_platform.h
+++ b/fresnel/cpu/embree_platform.h
@@ -8,7 +8,7 @@
 #include "common/VectorMath.h"
 #include <limits>
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 
 /*! Per the Embree documentation, this intersection context structure has the same data layout as
    the one in Embree's header, with extra custom bits at the end.
@@ -24,7 +24,7 @@ struct FresnelRTCIntersectContext
     {
     FresnelRTCIntersectContext() : d(std::numeric_limits<float>::max()) { }
 
-    RTCIntersectContext context;
+    RTCRayQueryContext context;
 
     // ray extensions go here
     float d; //!< Distance to the nearest edge


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add support for Embree 4 and remove support for Embree 3.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to build fresnel with the latest version of Embree.

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Support for Embree 4.x.

Removed

* Support for Embree 3.x.
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
