### PR TITLE
Test only on GCC9+, Python3.8+, and Clang10+.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2023.02-ubuntu22.04
+      image: glotzerlab/ci:2023.11.27-ubuntu22.04
 
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -48,6 +48,7 @@ jobs:
         - {repository: glotzerlab, image: gcc10_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc9_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: joaander, image: optix60_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
+        - {repository: joaander, image: optix60_cuda120_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
 
     steps:
     - uses: actions/checkout@v4.1.1
@@ -103,6 +104,7 @@ jobs:
         - {repository: glotzerlab, image: gcc10_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc9_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: joaander, image: optix60_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
+        - {repository: joaander, image: optix60_cuda120_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
 
     steps:
     - name: Clean workspace

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build [${{ matrix.image }}]
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.repository }}/ci:2023.02-${{ matrix.image }}
+      image: ${{ matrix.repository }}/ci:2023.11.27-${{ matrix.image }}
       credentials:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -38,17 +38,19 @@ jobs:
     strategy:
       matrix:
         include:
+        - {repository: glotzerlab, image: clang16_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
+        - {repository: glotzerlab, image: clang15_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
         - {repository: glotzerlab, image: clang14_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
         - {repository: glotzerlab, image: clang13_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang12_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang10_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc13_py312, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc12_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc10_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc9_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: joaander, image: optix60_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
-        - {repository: joaander, image: optix60_cuda120_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
+        - {repository: joaander, image: optix65_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
 
     steps:
     - uses: actions/checkout@v4.1.1
@@ -94,17 +96,19 @@ jobs:
     strategy:
       matrix:
         include:
+        - {repository: glotzerlab, image: clang16_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
+        - {repository: glotzerlab, image: clang15_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
         - {repository: glotzerlab, image: clang14_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: true }
         - {repository: glotzerlab, image: clang13_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang12_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang10_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
+        - {repository: glotzerlab, image: gcc13_py312, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc12_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc10_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc9_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: joaander, image: optix60_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
-        - {repository: joaander, image: optix60_cuda120_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
+        - {repository: joaander, image: optix65_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
 
     steps:
     - name: Clean workspace

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -87,7 +87,7 @@ jobs:
     needs: build_linux
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: ${{ matrix.repository }}/ci:2023.02-${{ matrix.image }}
+      image: ${{ matrix.repository }}/ci:2023.11.27-${{ matrix.image }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
       credentials:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -43,16 +43,10 @@ jobs:
         - {repository: glotzerlab, image: clang12_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang10_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang9_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang8_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang7_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang6_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc12_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc10_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc9_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: gcc8_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: gcc7_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: joaander, image: optix60_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
 
     steps:
@@ -104,16 +98,10 @@ jobs:
         - {repository: glotzerlab, image: clang12_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: clang10_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang9_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang8_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang7_py38, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: clang6_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc12_py311, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc11_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc10_py310, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: glotzerlab, image: gcc9_py39, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: gcc8_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
-        - {repository: glotzerlab, image: gcc7_py37, test_runner: ubuntu-latest, test_docker_options: '', render_gallery: false }
         - {repository: joaander, image: optix60_cuda118_py310, test_runner: [self-hosted,GPU,optix], test_docker_options: '-e  NVIDIA_DRIVER_CAPABILITIES=compute,graphics --gpus=all', render_gallery: false }
 
     steps:
@@ -166,13 +154,6 @@ jobs:
       with:
         path: code
         submodules: true
-    # setup-miniconda doesn't understand .conda format packages and removes them
-    # - name: Cache conda packages
-    #   uses: actions/cache@v3.2.4
-    #   with:
-    #     path: ~/conda_pkgs_dir
-    #     key:
-    #       ${{ matrix.os }}-${{ hashFiles('code/.github/workflows/environments/conda.yml') }}
     - name: Create conda environment
       uses: conda-incubator/setup-miniconda@v2.3.0
       with:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
* Remove old Python, GCC, and Clang entries from the test matrix.
* Add Python 3.12 and the latest versions of Python, GCC, and clang.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Test fresnel on currently supported compilers and python versions.

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* No longer test with GCC 7-8, Python 3.7, or Clang 6-9.

Added:

* Support Python 3.12 and GCC 13.
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
