### PR TITLE
Fix edge case for intersect function for convex polyhedron

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ fresnel_ releases follow `semantic versioning`_.
 0.x
 ----
 
+*Changed*
+
+* Fixed a bug in the intersect function for an edge case.
+
 0.13.6 (2024-05-31)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -16,6 +16,9 @@ The following people contributed to **fresnel**.
 * Mike Henry, Boise State University
 * Jenny Fothergill, Boise State University
 * Corwin Kerr, University of Michigan
+* Domagoj Fijan, University of Michigan
+* Charlotte Zhao, University of Michigan
+* Philipp Schönhöfer, University of Michigan
 
 Libraries
 ---------

--- a/fresnel/cpu/GeometryConvexPolyhedron.cc
+++ b/fresnel/cpu/GeometryConvexPolyhedron.cc
@@ -163,7 +163,7 @@ void GeometryConvexPolyhedron::intersect(const struct RTCIntersectFunctionNArgum
     vec3<float> t0_n_local(0, 0, 0), t0_p_local(0, 0, 0);
     vec3<float> t1_n_local(0, 0, 0), t1_p_local(0, 0, 0);
     int t0_plane_hit = 0, t1_plane_hit = 0;
-    for (int i = 0; i < n_planes && t0 < t1; ++i)
+    for (int i = 0; i < n_planes && t0 <= t1; ++i)
         {
         vec3<float> n = geom->m_plane_normal[i];
         vec3<float> p = geom->m_plane_origin[i];

--- a/fresnel/gpu/GeometryConvexPolyhedron.cu
+++ b/fresnel/gpu/GeometryConvexPolyhedron.cu
@@ -132,7 +132,7 @@ RT_PROGRAM void intersect(int item)
     vec3<float> t0_n_local(0, 0, 0), t0_p_local(0, 0, 0);
     vec3<float> t1_n_local(0, 0, 0), t1_p_local(0, 0, 0);
     int t0_plane_hit = 0, t1_plane_hit = 0;
-    for (int i = 0; i < n_planes && t0 < t1; ++i)
+    for (int i = 0; i < n_planes && t0 <= t1; ++i)
         {
         vec3<float> n = vec3<float>(convex_polyhedron_plane_normal[i]);
         vec3<float> p = vec3<float>(convex_polyhedron_plane_origin[i]);


### PR DESCRIPTION
## Description
Fixes edge case in ray intersect detection on convex polyhedrons.

## Motivation and context
During SPOONE development we realized that the intersect function is not treating some edge cases correctly. This fixes the issues we were having.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/fresnel/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Fresnel Contributor Agreement**](https://github.com/glotzerlab/fresnel/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/fresnel/blob/master/doc/credits.rst).
- [x] I have added a change log entry to `CHANGELOG.rst`.
